### PR TITLE
fix(utils): Don't encode response links

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -147,8 +147,7 @@ pub async fn filter_images_by_language(
         } else {
           &*boys::GITHUB_USER_CONTENT
         },
-        // URL (percent) encoding because we are pushing a URL, not a string
-        quote(item.path, b"").ok().unwrap()
+        item.path
       ));
     }
   }


### PR DESCRIPTION
* We return application/json content, which shouldn't need decoding from the client side, unlike application/x-www-form-urlencoded
* Stop encoding the URL inside the responses

Change-Id: I7023f4b811ab7c2e9b7f8987ea0991cfc725a374
